### PR TITLE
Update CI, dependencies, and Go version to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,13 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.25.x, 1.26.x]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: WillAbides/setup-go-faster@main
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - uses: actions/checkout@v4
-      with:
-         path: './src/github.com/kevinburke/go-types'
-    # staticcheck needs this for GOPATH
-    - run: |
-        echo "GOPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-        echo "PATH=$GITHUB_WORKSPACE/bin:$PATH" >> $GITHUB_ENV
     - name: Run tests
       run: make race-test
-      working-directory: './src/github.com/kevinburke/go-types'

--- a/doc.go
+++ b/doc.go
@@ -1,60 +1,60 @@
 /*
-	Package types implements several types for dealing with REST API's and
-	databases.
+Package types implements several types for dealing with REST API's and
+databases.
 
-	PrefixUUID
+# PrefixUUID
 
-	UUID's are very useful, but you often need to attach context to them; e.g.
-	you cannot look at a UUID and know whether it points to a record in the
-	accounts table or in the messages table. A PrefixUUID solves this problem,
-	by embedding the additional useful information as part of the string.
+UUID's are very useful, but you often need to attach context to them; e.g.
+you cannot look at a UUID and know whether it points to a record in the
+accounts table or in the messages table. A PrefixUUID solves this problem,
+by embedding the additional useful information as part of the string.
 
-		a, _ := types.NewPrefixUUID("account6740b44e-13b9-475d-af06-979627e0e0d6")
-		fmt.Println(a.Prefix) // "account"
-		fmt.Println(a.UUID.String()) "6740b44e-13b9-475d-af06-979627e0e0d6"
-		fmt.Println(a.String()) "account6740b44e-13b9-475d-af06-979627e0e0d6"
+	a, _ := types.NewPrefixUUID("account6740b44e-13b9-475d-af06-979627e0e0d6")
+	fmt.Println(a.Prefix) // "account"
+	fmt.Println(a.UUID.String()) "6740b44e-13b9-475d-af06-979627e0e0d6"
+	fmt.Println(a.String()) "account6740b44e-13b9-475d-af06-979627e0e0d6"
 
-	If we had to write this value to the database as a string it would take up
-	43 bytes. Instead we use a UUID type and strip the prefix before saving it.
+If we had to write this value to the database as a string it would take up
+43 bytes. Instead we use a UUID type and strip the prefix before saving it.
 
-	The converse, Value(), only returns the UUID part by default, since this
-	is the only thing the database knows about. You can also attach the prefix
-	manually in your SQL, like so:
+The converse, Value(), only returns the UUID part by default, since this
+is the only thing the database knows about. You can also attach the prefix
+manually in your SQL, like so:
 
-		SELECT 'job_' || id, created_at FROM jobs;
+	SELECT 'job_' || id, created_at FROM jobs;
 
-	This will get parsed as part of the Scan(), and then you don't need to
-	do anything. Alternatively, you can attach the prefix in your model,
-	immediately after the query.
+This will get parsed as part of the Scan(), and then you don't need to
+do anything. Alternatively, you can attach the prefix in your model,
+immediately after the query.
 
-		func Get(id types.PrefixUUID) *User {
-			var uid types.PrefixUUID
-			var email string
-			db.Conn.QueryRow("SELECT * FROM users WHERE id = $1").Scan(&uid, &email)
-			uid.Prefix = "usr"
-			return &User{
-				ID: uid,
-				Email: email
-			}
+	func Get(id types.PrefixUUID) *User {
+		var uid types.PrefixUUID
+		var email string
+		db.Conn.QueryRow("SELECT * FROM users WHERE id = $1").Scan(&uid, &email)
+		uid.Prefix = "usr"
+		return &User{
+			ID: uid,
+			Email: email
 		}
+	}
 
-	NullString
+# NullString
 
-	A NullString is like the null string in `database/sql`, but can additionally
-	be encoded/decoded via JSON.
+A NullString is like the null string in `database/sql`, but can additionally
+be encoded/decoded via JSON.
 
-		json.NewEncoder(os.Stdout).Encode(NullString{Valid: false})
-		// Output: null
-		json.NewEncoder(os.Stdout).Encode(NullString{Valid: true, String: "hello"})
-		// Output: "hello"
+	json.NewEncoder(os.Stdout).Encode(NullString{Valid: false})
+	// Output: null
+	json.NewEncoder(os.Stdout).Encode(NullString{Valid: true, String: "hello"})
+	// Output: "hello"
 
-	NullTime
+# NullTime
 
-	A NullTime behaves exactly like NullString, but the value is a time.Time.
+A NullTime behaves exactly like NullString, but the value is a time.Time.
 
-		json.NewEncoder(os.Stdout).Encode(NullTime{Valid: false})
-		// Output: null
-		json.NewEncoder(os.Stdout).Encode(NullTime{Valid: true, Time: time.Now()})
-		// Output: "2016-05-02T08:33:46.005852482-07:00"
+	json.NewEncoder(os.Stdout).Encode(NullTime{Valid: false})
+	// Output: null
+	json.NewEncoder(os.Stdout).Encode(NullTime{Valid: true, Time: time.Now()})
+	// Output: "2016-05-02T08:33:46.005852482-07:00"
 */
 package types

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/kevinburke/go-types
 
-go 1.21
+go 1.25
 
-require github.com/gofrs/uuid v4.4.0+incompatible
+require github.com/gofrs/uuid/v5 v5.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
-github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
+github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=

--- a/null_time.go
+++ b/null_time.go
@@ -46,7 +46,7 @@ func (nt NullTime) MarshalJSON() ([]byte, error) {
 }
 
 // Scan implements the Scanner interface.
-func (nt *NullTime) Scan(value interface{}) error {
+func (nt *NullTime) Scan(value any) error {
 	nt.Time, nt.Valid = value.(time.Time)
 	return nil
 }

--- a/prefix.go
+++ b/prefix.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/gofrs/uuid/v5"
 )
 
 // A PrefixUUID stores an additional prefix as part of a UUID type.
@@ -72,7 +72,7 @@ func (pu PrefixUUID) MarshalJSON() ([]byte, error) {
 // Scan implements the Scanner interface. Note only the UUID gets scanned/set
 // here, we can't determine the prefix from the database. `value` should be
 // a [16]byte
-func (pu *PrefixUUID) Scan(value interface{}) error {
+func (pu *PrefixUUID) Scan(value any) error {
 	if value == nil {
 		return errors.New("types: cannot scan null into a PrefixUUID")
 	}

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	uuid "github.com/gofrs/uuid"
+	uuid "github.com/gofrs/uuid/v5"
 )
 
 func ExamplePrefixUUID() {
@@ -66,7 +66,7 @@ var unmarshalTests = []struct {
 func TestUUIDUnmarshal(t *testing.T) {
 	for _, tt := range unmarshalTests {
 		var pfxu PrefixUUID
-		err := json.Unmarshal([]byte(fmt.Sprintf("\"%s\"", tt.in)), &pfxu)
+		err := json.Unmarshal(fmt.Appendf(nil, "\"%s\"", tt.in), &pfxu)
 		if tt.err != nil {
 			assertError(t, err, "")
 			assertEquals(t, err.Error(), tt.err.Error())

--- a/tools_test.go
+++ b/tools_test.go
@@ -49,7 +49,7 @@ func assertError(t *testing.T, err error, message string) {
 }
 
 // AssertEquals uses the equality operator (==) to measure one and two
-func assertEquals(t *testing.T, one interface{}, two interface{}) {
+func assertEquals(t *testing.T, one any, two any) {
 	if one != two {
 		t.Fatalf("%s [%v] != [%v]", caller(), one, two)
 	}

--- a/types.go
+++ b/types.go
@@ -42,7 +42,7 @@ func (ns NullString) MarshalJSON() ([]byte, error) {
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullString) Scan(value interface{}) error {
+func (ns *NullString) Scan(value any) error {
 	if value == nil {
 		ns.String, ns.Valid = "", false
 		return nil
@@ -138,7 +138,7 @@ func fmtFrac(buf []byte, v uint64, prec int) (nw int, nv uint64) {
 	// Omit trailing zeros up to and including decimal point.
 	w := len(buf)
 	print := false
-	for i := 0; i < prec; i++ {
+	for range prec {
 		digit := v % 10
 		print = print || digit != 0
 		if print {


### PR DESCRIPTION
- CI: Go 1.21/1.22 → 1.25/1.26, switch to actions/setup-go@v5, remove legacy GOPATH checkout pattern
- Deps: gofrs/uuid v4.4.0 → v5.4.0
- go.mod: go 1.21 → go 1.25
- go fix/fmt: interface{} → any, for-range int, fmt.Appendf, doc comments