### PR TITLE
github: add daily Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add a Dependabot configuration for GitHub Actions and Go modules.
This repository uses a GitHub Actions workflow and a Go module, so
those are the primary ecosystems that should receive daily update
checks.

